### PR TITLE
Don't send access token in query parameter when getting userinfo

### DIFF
--- a/lib/passport-dataporten/oauth2.js
+++ b/lib/passport-dataporten/oauth2.js
@@ -93,6 +93,7 @@ util.inherits(Strategy, OAuth2Strategy);
 Strategy.prototype.userProfile = function(accessToken, done) {
 
 	var that = this;
+	this._oauth2.useAuthorizationHeaderforGET(true);
 	this._oauth2.get(
 		this.profileUrl,
 		accessToken,


### PR DESCRIPTION
Passing access token in means that the access token will be visible in
access logs etc and is a bad idea.